### PR TITLE
Filter out vite client logs

### DIFF
--- a/examples/react/web-test-runner.config.js
+++ b/examples/react/web-test-runner.config.js
@@ -1,4 +1,10 @@
 const vite = require('vite-web-test-runner-plugin');
+
+const ignoredBrowserLogs = [
+  '[vite] connecting...',
+  '[vite] connected.',
+];
+
 module.exports = {
   plugins: [
     vite(),
@@ -25,4 +31,7 @@ module.exports = {
       </head>
     </html>
   `,
+  filterBrowserLogs: ({ args }) => {
+    return !args.some((arg) => ignoredBrowserLogs.includes(arg));
+  },
 };

--- a/examples/svelte/web-test-runner.config.js
+++ b/examples/svelte/web-test-runner.config.js
@@ -1,4 +1,10 @@
 const vite = require('vite-web-test-runner-plugin');
+
+const ignoredBrowserLogs = [
+  '[vite] connecting...',
+  '[vite] connected.',
+];
+
 module.exports = {
   plugins: [
     vite(),
@@ -20,4 +26,7 @@ module.exports = {
       </head>
     </html>
   `,
+  filterBrowserLogs: ({ args }) => {
+    return !args.some((arg) => ignoredBrowserLogs.includes(arg));
+  },
 };

--- a/examples/vue/web-test-runner.config.js
+++ b/examples/vue/web-test-runner.config.js
@@ -1,4 +1,10 @@
 const vite = require('vite-web-test-runner-plugin');
+
+const ignoredBrowserLogs = [
+  '[vite] connecting...',
+  '[vite] connected.',
+];
+
 module.exports = {
   plugins: [
     vite(),
@@ -20,4 +26,7 @@ module.exports = {
       </head>
     </html>
   `,
+  filterBrowserLogs: ({ args }) => {
+    return !args.some((arg) => ignoredBrowserLogs.includes(arg));
+  },
 };


### PR DESCRIPTION
Closes #7 

These logs are shown for every single test, and don't add value, so we can filter them out.  This PR adds to the examples to show how.